### PR TITLE
added cfe_py as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cfe_py"]
+	path = cfe_py
+	url = https://github.com/NWC-CUAHSI-Summer-Institute/cfe_py.git


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

added cfe_py as submodule

## Removals

N/A

## Testing

1. Ran the CFE Perturbed notebook through the DA repo, and it works.

## Notes

- Adding the cfe_py github repo as a submodule will allow use to run it without copying over the whole directory. And, we don't need to copy over code.

## Todos

- Add in a PET submodule as well